### PR TITLE
Update to 2.5.17 + change name of package to winflexbison_installer 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(cmake_wrapper)
 
-include(conanbuildinfo.cmake)
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup()
 
-add_subdirectory("source_subfolder")
+add_subdirectory(sources)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,4 @@ project(cmake_wrapper)
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup()
 
-add_subdirectory(sources)
+add_subdirectory(source_subfolder)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,12 @@
 build: false
 
 environment:
-    PYTHON: "C:\\Python27"
-    PYTHON_VERSION: "2.7.15"
-    PYTHON_ARCH: "32"
+    PYTHON: "C:\\Python37"
 
     matrix:
-        #- MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix, 4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix, 6@x86_64@seh@posix, 7@x86_64@seh@posix'
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Release
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Debug
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Release
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Debug
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/

--- a/build.py
+++ b/build.py
@@ -2,10 +2,13 @@
 # -*- coding: utf-8 -*-
 
 
-from bincrafters import build_template_default
+from bincrafters import build_shared, build_template_default
 
 if __name__ == "__main__":
 
-    builder = build_template_default.get_builder()
+    builder = build_shared.get_builder()
+
+    builder.add(settings={"arch_build": "x86",})
+    builder.add(settings={"arch_build": "x86_64",})
 
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,6 @@ import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import shutil
-import tempfile
 
 
 class WinflexbisonConan(ConanFile):
@@ -24,8 +23,9 @@ class WinflexbisonConan(ConanFile):
 
     def configure(self):
         self.settings.arch = str(self.settings.arch_build)
-        if self.settings.compiler != "Visual Studio":
-            raise ConanInvalidConfiguration("winflexbison is only supported for Visual Studio.")
+        if not self.in_local_cache:
+            if self.settings.compiler != "Visual Studio":
+                raise ConanInvalidConfiguration("Building winflexbison is only supported for Visual Studio.")
 
     def package_id(self):
         self.info.include_build_settings()

--- a/conanfile.py
+++ b/conanfile.py
@@ -28,6 +28,7 @@ class WinflexbisonConan(ConanFile):
             raise ConanInvalidConfiguration("winflexbison is only supported for Visual Studio.")
 
     def package_id(self):
+        self.info.include_build_settings()
         del self.info.settings.arch
         del self.info.settings.compiler
         del self.info.settings.build_type

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ import tempfile
 
 
 class WinflexbisonConan(ConanFile):
-    name = "winflexbison_installer"
+    name = "winflexbison"
     version = "2.5.17"
     description = "Flex and Bison for Windows"
     url = "https://github.com/bincrafters/conan-winflexbison"
@@ -20,7 +20,7 @@ class WinflexbisonConan(ConanFile):
     generators = "cmake"
     settings = "arch", "os_build", "arch_build", "compiler", "build_type"
 
-    _source_subfolder = "sources"
+    _source_subfolder = "source_subfolder"
 
     def configure(self):
         self.settings.arch = str(self.settings.arch_build)
@@ -34,21 +34,8 @@ class WinflexbisonConan(ConanFile):
         del self.info.settings.build_type
 
     def source(self):
-        name = "winflexbison"
-        url = "https://github.com/lexxmark/winflexbison/archive/v{}.tar.gz".format(self.version)
-        sha256 = "2ab4c895f9baf03dfdfbb2dc4abe60e87bf46efe12ed1218c38fd7761f0f58fc"
-        filename = "{}-{}.tar.gz".format(name, self.version)
-
-        dlfilepath = os.path.join(tempfile.gettempdir(), filename)
-        if os.path.exists(dlfilepath) and not tools.get_env("WINFLEXBISON_FORCE_DOWNLOAD", False):
-            self.output.info("Skipping download. Using cached {}".format(dlfilepath))
-        else:
-            self.output.info("Downloading {} from {}".format(name, url))
-            tools.download(url, dlfilepath)
-        tools.check_sha256(dlfilepath, sha256)
-        tools.untargz(dlfilepath)
-
-        extracted_dir = "{}-{}".format(name, self.version)
+        tools.get("{0}/archive/v{1}.tar.gz".format(self.homepage, self.version), sha256="2ab4c895f9baf03dfdfbb2dc4abe60e87bf46efe12ed1218c38fd7761f0f58fc")
+        extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
         # Generate license from header of a source file
@@ -78,6 +65,7 @@ class WinflexbisonConan(ConanFile):
                 pass
             cmake.install(args=["--config", str(self.settings.build_type)])
 
+        self.copy("LICENSE.md", dst="licenses")
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
 
         self.copy(pattern="*.exe", src=self._fake_package, dst="bin",keep_path=False)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,80 @@
+project(test_package)
+cmake_minimum_required(VERSION 3.0)
+
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(NO_OUTPUT_DIRS)
+
+message(STATUS "Configuring Flex test package targets")
+
+set(FLEX_TARGET_COMPILE_FLAGS "")
+if(MSVC)
+    set(FLEX_TARGET_COMPILE_FLAGS "--wincompat")
+endif()
+
+find_package(FLEX)
+
+set(FLEX_VARS
+    FLEX_FOUND
+    FLEX_EXECUTABLE
+    FLEX_LIBRARIES
+    FLEX_INCLUDE_DIRS
+)
+
+foreach(FLEX_VAR ${FLEX_VARS})
+    message("${FLEX_VAR}: ${${FLEX_VAR}}")
+    if(NOT ${FLEX_VAR})
+        message(WARNING "${FLEX_VAR} NOT FOUND")
+    endif()
+endforeach()
+
+
+FLEX_TARGET(TestParser basic_nr.l "${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp"
+    COMPILE_FLAGS "${FLEX_TARGET_COMPILE_FLAGS}")
+
+add_executable(flex_test_package
+    ${FLEX_TestParser_OUTPUTS}
+)
+
+enable_testing()
+add_test(TestLexer
+    flex_test_package "${CMAKE_CURRENT_LIST_DIR}/basic_nr.txt"
+)
+
+message(STATUS "Configuring Bison test package targets")
+
+find_package(BISON)
+
+set(BISON_VARS
+    BISON_FOUND
+    BISON_EXECUTABLE
+    BISON_VERSION
+)
+
+foreach(BISON_VAR ${BISON_VARS})
+    message("${BISON_VAR}: ${${BISON_VAR}}")
+    if(NOT ${BISON_VAR})
+        message(WARNING "${BISON_VAR} NOT FOUND")
+    endif()
+endforeach()
+
+bison_target(bison_parser_target
+    mc_parser.yy "${CMAKE_CURRENT_BINARY_DIR}/mc_parser.cpp"
+)
+
+add_executable(bison_test_package
+    "${CMAKE_CURRENT_BINARY_DIR}/mc_parser.cpp"
+    dummy_lex.cpp
+)
+target_include_directories(bison_test_package
+    PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+enable_testing()
+add_test(TestBison
+    bison_test_package
+)

--- a/test_package/basic_nr.l
+++ b/test_package/basic_nr.l
@@ -1,0 +1,77 @@
+/*
+ * This file is part of flex.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * Neither the name of the University nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+
+/* TEST scanner.
+   Basic non-reentrant scanner.
+
+   Sample Input:
+       # this is a comment
+       foo = true
+       bar = "string value"
+       integer = 43
+*/
+%{
+/* #include "config.h" */
+%}
+
+%option prefix="test"
+%option nounput noyywrap noyylineno warn nodefault noinput
+
+IDENT [[:alnum:]_-]
+WS    [[:blank:]]
+%%
+
+^{IDENT}+{WS}*={WS}*(true|false){WS}*\r?\n    { return 100;}
+^{IDENT}+{WS}*={WS}*\"[^\"\n\r]*\"{WS}*\r?\n  { return 101;}
+^{IDENT}+{WS}*={WS}*[[:digit:]]+{WS}*\r?\n    { return 102;}
+^{WS}*#.*\r?\n     { }
+^{WS}*\r?\n        { }
+.|\n  { fprintf(stderr,"Invalid line.\n"); exit(-1);}
+
+%%
+
+#include <stdio.h>
+
+int main(int argc, char **argv);
+
+int main (int argc, char **argv)
+{
+    FILE *input = NULL;
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <FILE>\n", argv[0]);
+        return 1;
+    }
+    input = fopen(argv[1], "r");
+    if (input == NULL) {
+        fprintf(stderr, "Failed to open '%s'\n", argv[1]);
+        return 1;
+    }
+    yyin = input;
+    yyout = stdout;
+    while( yylex() )
+    {
+    }
+    printf("TEST RETURNING OK.\n");
+    fclose(input);
+    return 0;
+}

--- a/test_package/basic_nr.txt
+++ b/test_package/basic_nr.txt
@@ -1,0 +1,5 @@
+# this is a comment
+foo = "bar"
+num = 43
+setting = false
+

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
 
 from conans import ConanFile, CMake
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
@@ -13,6 +10,5 @@ class TestPackageConan(ConanFile):
     def test(self):
         self.run("win_flex --version", run_environment=True)
         self.run("win_bison --version", run_environment=True)
-
-        #bin_path = os.path.join("bin", "test_package")
-        #self.run(bin_path, run_environment=True)
+        self.run("flex --version", run_environment=True)
+        self.run("bison --version", run_environment=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,14 +1,24 @@
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, CMake
-import os
+from conans import ConanFile, CMake, tools, RunEnvironment
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         self.run("win_flex --version", run_environment=True)
         self.run("win_bison --version", run_environment=True)
         self.run("flex --version", run_environment=True)
         self.run("bison --version", run_environment=True)
+
+        if not tools.cross_building(self.settings):
+            with tools.environment_append(RunEnvironment(self).vars):
+                cmake = CMake(self)
+                cmake.test()

--- a/test_package/dummy_lex.cpp
+++ b/test_package/dummy_lex.cpp
@@ -1,0 +1,21 @@
+#include "mc_parser.hpp"
+
+namespace {
+    const int VARS[] = {
+        NUM,
+        OPA,
+        NUM,
+        STOP,
+        0,
+    };
+}
+
+int yylex() {
+    static unsigned pos = 0;
+    if (pos > (sizeof(VARS) / sizeof(*VARS))) {
+        return 0;
+    }
+    int r = VARS[pos];
+    ++pos;
+    return r;
+}

--- a/test_package/mc_parser.yy
+++ b/test_package/mc_parser.yy
@@ -1,0 +1,42 @@
+%{
+#include <iostream>
+#include <string>
+#include <map>
+#include <cstdlib> //-- I need this for atoi
+using namespace std;
+
+int yylex();
+int yyerror(const char *p) { cerr << "Error: " << p << endl; return 0; }
+%}
+
+%union {
+  int val;
+  char sym;
+};
+%token <val> NUM
+%token <sym> OPA OPM LP RP STOP
+%type  <val> exp term sfactor factor res
+
+%%
+run: res run | res    /* forces bison to process many stmts */
+
+res: exp STOP         { cout << $1 << endl; }
+
+exp: exp OPA term     { $$ = ($2 == '+' ? $1 + $3 : $1 - $3); }
+| term                { $$ = $1; }
+
+term: term OPM factor { $$ = ($2 == '*' ? $1 * $3 : $1 / $3); }
+| sfactor             { $$ = $1; }
+
+sfactor: OPA factor   { $$ = ($1 == '+' ? $2 : -$2); }
+| factor              { $$ = $1; }
+
+factor: NUM           { $$ = $1; }
+| LP exp RP           { $$ = $2; }
+
+%%
+int main()
+{
+  yyparse();
+  return 0;
+}


### PR DESCRIPTION
- Updated to 2.5.17
- needs a testing/2.5.17 branch, so ci will fail
- changed name to winflexbison_installer because the recipe is binary only, so it can be used as `build_requires`
- ci: https://ci.appveyor.com/project/madebr/conan-winflexbison
